### PR TITLE
fix python3.6 missing in ubuntu-latest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Since October, `ubuntu-latest` correspond to ubuntu-22.04 in GithubActions. (https://github.com/actions/runner-images/issues/6399) 
As python 3.6 is not present in Ubuntu-22.04, we may fix Ubuntu version to 20.04 for now. I will maybe drop python3.6 support if needed to python >= 3.8.